### PR TITLE
Fix z-ordering

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -47,7 +47,7 @@ function Camera(eye,lookat,up,fov)
 
 		let x = p[0] / p[3];
 		let y = p[1] / p[3];
-		let z = p[2];
+		let z = p[2] / p[3];
 		if (!v_out)
 			return createVector(x,y,z);
 


### PR DESCRIPTION
Screen coordinates are used in the calculation of baryonic coordinates,
but the calculation of the z-coordinate is done in a way that breaks the
invariant of straight lines remaining straight.

This fix divides the z-coordinate by the same as the x and y coordinates
are divided.

z' = (z-1)/z

This projects z = [1..+inf] onto z' = [0..1]

Reproducible problem:

```
scale([.1,50,10])
rotate([90,0,90])
cylinder(1,1,1,$fn=3);
translate([-4.01,0,0])
sphere(4);
```
